### PR TITLE
Add smart lithium battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Supported Devices & Entities:
   - Output Current (A)
   - Off Reason
   - Charger Error
+- Smart Lithium Battery
+  - Voltage (V)
+  - Temperature (°C)
+  - Cell Voltages (V)
+  - Balancing Status
+  - BMS Flags
+  - Error Flags
 
 # Installation
 

--- a/custom_components/victron_ble/device.py
+++ b/custom_components/victron_ble/device.py
@@ -370,13 +370,13 @@ class VictronBluetoothDeviceData(BluetoothData):
         elif isinstance(parsed, SmartLithiumData):
             self.update_sensor(
                 key=VictronSensor.BMS_FLAGS,
-                name="BMS flags",
+                name="BMS Flags",
                 native_unit_of_measurement=None,
                 native_value=parsed.get_bms_flags(),
             )
             self.update_sensor(
                 key=VictronSensor.ERROR_FLAGS,
-                name="Error flags",
+                name="Error Flags",
                 native_unit_of_measurement=None,
                 native_value=parsed.get_error_flags(),
             )

--- a/custom_components/victron_ble/device.py
+++ b/custom_components/victron_ble/device.py
@@ -51,6 +51,7 @@ class VictronSensor(StrEnum):
     BMS_FLAGS = "bms_flags"
     ERROR_FLAGS = "error_flags"
     BALANCER_STATUS = "balancer_status"
+    CELL_VOLTAGE = "cell_voltage"
 
 
 class VictronBluetoothDeviceData(BluetoothData):
@@ -391,7 +392,13 @@ class VictronBluetoothDeviceData(BluetoothData):
                 native_value=parsed.get_battery_temperature(),
                 device_class=SensorDeviceClass.TEMPERATURE,
             )
-            # cell voltages (dont know how to handle lists here)
+            for i, cell_voltage in enumerate(parsed.get_cell_voltages()):
+                self.update_sensor(
+                    key=VictronSensor.CELL_VOLTAGE + "_" + str(i+1),
+                    native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+                    native_value=cell_voltage,
+                    device_class=SensorDeviceClass.VOLTAGE,
+                )
             self.update_sensor(
                 key=VictronSensor.BALANCER_STATUS,
                 native_unit_of_measurement=None,

--- a/custom_components/victron_ble/device.py
+++ b/custom_components/victron_ble/device.py
@@ -15,6 +15,7 @@ from victron_ble.devices.inverter import InverterData
 from victron_ble.devices.orion_xs import OrionXSData
 from victron_ble.devices.solar_charger import SolarChargerData
 from victron_ble.devices.vebus import VEBusData
+from victron_ble.devices.smart_lithium import SmartLithiumData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +48,9 @@ class VictronSensor(StrEnum):
     ALARM_REASON = "alarm_reason"
     ALARM_NOTIFICATION = "alarm_notification"
     CONSUMED = "consumed"
+    BMS_FLAGS = "bms_flags"
+    ERROR_FLAGS = "error_flags"
+    BALANCER_STATUS = "balancer_status"
 
 
 class VictronBluetoothDeviceData(BluetoothData):
@@ -361,5 +365,40 @@ class VictronBluetoothDeviceData(BluetoothData):
                 native_value=enum_to_native_value(parsed.get_alarm()),
                 device_class=SensorDeviceClass.ENUM,
             )
+            
+        elif isinstance(parsed, SmartLithiumData):
+            self.update_sensor(
+                key=VictronSensor.BMS_FLAGS,
+                name="BMS flags",
+                native_unit_of_measurement=None,
+                native_value=parsed.get_bms_flags(),
+            )
+            self.update_sensor(
+                key=VictronSensor.ERROR_FLAGS,
+                name="Error flags",
+                native_unit_of_measurement=None,
+                native_value=parsed.get_error_flags(),
+            )
+            self.update_sensor(
+                key=VictronSensor.BATTERY_VOLTAGE,
+                native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+                native_value=parsed.get_battery_voltage(),
+                device_class=SensorDeviceClass.VOLTAGE,
+            )
+            self.update_sensor(
+                key=VictronSensor.BATTERY_TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+                native_value=parsed.get_battery_temperature(),
+                device_class=SensorDeviceClass.TEMPERATURE,
+            )
+            # cell voltages (dont know how to handle lists here)
+            
+            # enum missing in victron-ble
+#             self.update_sensor(
+#                 key=VictronSensor.BALANCER_STATUS,
+#                 native_unit_of_measurement=None,
+#                 native_value=enum_to_native_value(parsed.get_balancer_status()),
+#                 device_class=SensorDeviceClass.ENUM,
+#             )
 
         return

--- a/custom_components/victron_ble/device.py
+++ b/custom_components/victron_ble/device.py
@@ -392,13 +392,11 @@ class VictronBluetoothDeviceData(BluetoothData):
                 device_class=SensorDeviceClass.TEMPERATURE,
             )
             # cell voltages (dont know how to handle lists here)
-            
-            # enum missing in victron-ble
-#             self.update_sensor(
-#                 key=VictronSensor.BALANCER_STATUS,
-#                 native_unit_of_measurement=None,
-#                 native_value=enum_to_native_value(parsed.get_balancer_status()),
-#                 device_class=SensorDeviceClass.ENUM,
-#             )
+            self.update_sensor(
+                key=VictronSensor.BALANCER_STATUS,
+                native_unit_of_measurement=None,
+                native_value=enum_to_native_value(parsed.get_balancer_status()),
+                device_class=SensorDeviceClass.ENUM,
+            )
 
         return

--- a/custom_components/victron_ble/sensor.py
+++ b/custom_components/victron_ble/sensor.py
@@ -224,6 +224,17 @@ SENSOR_DESCRIPTIONS: Dict[Tuple[SensorDeviceClass, Optional[Units]], Any] = {
         native_unit_of_measurement=Units.POWER_WATT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    (VictronSensor.BMS_FLAGS, None): SensorEntityDescription(
+        key=VictronSensor.BMS_FLAGS,
+    ),
+    (VictronSensor.ERROR_FLAGS, None): SensorEntityDescription(
+        key=VictronSensor.ERROR_FLAGS,
+    ),
+#     (VictronSensor.BALANCER_STATUS, None): SensorEntityDescription(
+#         key=VictronSensor.BALANCER_STATUS,
+#         device_class=SensorDeviceClass.ENUM,
+#         options=[x.lower() for x in BalancerStatus._member_names_],
+#     ),
 }
 
 

--- a/custom_components/victron_ble/sensor.py
+++ b/custom_components/victron_ble/sensor.py
@@ -26,6 +26,7 @@ from sensor_state_data.data import SensorUpdate
 from sensor_state_data.units import Units
 from victron_ble.devices.base import ACInState, AlarmNotification, AlarmReason, ChargerError, OffReason, OperationMode
 from victron_ble.devices.battery_monitor import AuxMode
+from victron_ble.devices.smart_lithium import BalancerStatus
 
 from .const import DOMAIN
 from .device import VictronSensor
@@ -230,11 +231,11 @@ SENSOR_DESCRIPTIONS: Dict[Tuple[SensorDeviceClass, Optional[Units]], Any] = {
     (VictronSensor.ERROR_FLAGS, None): SensorEntityDescription(
         key=VictronSensor.ERROR_FLAGS,
     ),
-#     (VictronSensor.BALANCER_STATUS, None): SensorEntityDescription(
-#         key=VictronSensor.BALANCER_STATUS,
-#         device_class=SensorDeviceClass.ENUM,
-#         options=[x.lower() for x in BalancerStatus._member_names_],
-#     ),
+    (VictronSensor.BALANCER_STATUS, None): SensorEntityDescription(
+        key=VictronSensor.BALANCER_STATUS,
+        device_class=SensorDeviceClass.ENUM,
+        options=[x.lower() for x in BalancerStatus._member_names_],
+    ),
 }
 
 

--- a/custom_components/victron_ble/sensor.py
+++ b/custom_components/victron_ble/sensor.py
@@ -236,6 +236,12 @@ SENSOR_DESCRIPTIONS: Dict[Tuple[SensorDeviceClass, Optional[Units]], Any] = {
         device_class=SensorDeviceClass.ENUM,
         options=[x.lower() for x in BalancerStatus._member_names_],
     ),
+    (VictronSensor.CELL_VOLTAGE, Units.ELECTRIC_POTENTIAL_VOLT): SensorEntityDescription(
+        key=VictronSensor.CELL_VOLTAGE,
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 }
 
 
@@ -252,7 +258,7 @@ def sensor_update_to_bluetooth_data_update(
             PassiveBluetoothEntityKey(
                 device_key.key, device_key.device_id
             ): SENSOR_DESCRIPTIONS[
-                (description.device_key.key, description.native_unit_of_measurement)
+                (VictronSensor.CELL_VOLTAGE if VictronSensor.CELL_VOLTAGE in description.device_key.key else description.device_key.key, description.native_unit_of_measurement)
             ]
             for device_key, description in sensor_update.entity_descriptions.items()
             if description.device_key


### PR DESCRIPTION
I’m not experienced with Python at all, but I needed this feature :). The handling of the list of cell voltages in sensor.py isn’t perfect. Maybe you’ll find a better solution than I did: https://github.com/j9brown/victron-hacs/compare/main...naofireblade:victron-hacs:main?expand=1#diff-f8da75d96fd84ef3f03e1eb0bda89d78a0dc0a381be342be6f2d80de87991ae9R261